### PR TITLE
Correct failing tests.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'blp-gemrc'
-version '1.0.2'
+version '1.0.3'
 maintainer 'Bloomberg Infrastructure Engineering'
 maintainer_email 'chef@bloomberg.net'
 license 'Apache-2.0'

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -4,6 +4,6 @@ describe file('/opt/chef/embedded/etc/gemrc') do
   its('owner') { should eq 'root' }
   its('group') { should eq 'root' }
   its('mode') { should eq 420 }
-  its('content') { should match(%r{":sources":\n - http://rubygems.org/}) }
+  its('content') { should match(%r{":sources":\n- http://rubygems.org/}) }
   its('content') { should match(%r{gem: "--no-ri --no-rdoc"}) }
 end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -4,10 +4,6 @@ describe file('/opt/chef/embedded/etc/gemrc') do
   its('owner') { should eq 'root' }
   its('group') { should eq 'root' }
   its('mode') { should eq 420 }
-  its('content') { should eq <<-GEMRC }
----
-":sources":
-- http://rubygems.org/
-gem: "--no-ri --no-rdoc"
-GEMRC
+  its('content') { should match(%r{":sources":\n - http://rubygems.org/}) }
+  its('content') { should match(%r{gem: "--no-ri --no-rdoc"}) }
 end


### PR DESCRIPTION
- We pass a hash to the resource but since key order isn't deterministic, we can't expect the resulting file to be written in the same order each time (i.e. `sources`, then `gem`).
- Let's test for the proper content, in any order, but formatted as expected.